### PR TITLE
Adopt PHPOffice/PHPWord's image alt text code

### DIFF
--- a/docs/changes/1.x/1.5.0.md
+++ b/docs/changes/1.x/1.5.0.md
@@ -3,6 +3,7 @@
 [Full Changelog](https://github.com/PHPOffice/PHPWord/compare/1.4.0...1.5.0)
 
 ## Enhancements
+- Added support for image alt text by [@jwoodhead](https://github.com/jwoodhead) in [#2873](https://github.com/PHPOffice/PHPWord/pull/2873)
 
 ### Bug fixes
 

--- a/docs/usage/elements/image.md
+++ b/docs/usage/elements/image.md
@@ -5,11 +5,14 @@ To add an image, use the ``addImage`` method to sections, headers, footers, text
 ``` php
 <?php
 
-$section->addImage($src, [$style]);
+$section->addImage($src, [$style], [$isWatermark], [$name], [$altText]);
 ```
 
 - ``$src``. String path to a local image, URL of a remote image or the image data, as a string. Warning: Do not pass user-generated strings here, as that would allow an attacker to read arbitrary files or perform server-side request forgery by passing file paths or URLs instead of image data.
 - ``$style``. See [`Styles > Image`](../styles/image.md).
+- ``$isWatermark``. Used by [`Elements > Watermark`](./watermark.md).
+- ``$name``. Name of the image.
+- ``$altText``. Description of the image used by screen readers.
 
 Examples:
 
@@ -30,7 +33,7 @@ $section->addImage(
 $footer = $section->addFooter();
 $footer->addImage('http://example.com/image.php');
 $textrun = $section->addTextRun();
-$textrun->addImage('http://php.net/logo.jpg');
+$textrun->addImage('http://php.net/logo.jpg', null, false, null, 'PHP logo');
 $source = file_get_contents('/path/to/my/images/earth.jpg');
-$textrun->addImage($source);
+$image = $textrun->addImage($source);
 ```

--- a/src/PhpWord/Element/AbstractContainer.php
+++ b/src/PhpWord/Element/AbstractContainer.php
@@ -40,7 +40,7 @@ use ReflectionClass;
  * @method TOC addTOC(mixed $fontStyle = null, mixed $tocStyle = null, int $minDepth = 1, int $maxDepth = 9)
  * @method PageBreak addPageBreak()
  * @method Table addTable(mixed $style = null)
- * @method Image addImage(string $source, mixed $style = null, bool $isWatermark = false, $name = null)
+ * @method Image addImage(string $source, mixed $style = null, bool $isWatermark = false, $name = null, $altText = null)
  * @method OLEObject addOLEObject(string $source, mixed $style = null)
  * @method TextBox addTextBox(mixed $style = null)
  * @method Field addField(string $type = null, array $properties = array(), array $options = array(), mixed $text = null)

--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -69,9 +69,16 @@ class Image extends AbstractElement
     /**
      * Name of image.
      *
-     * @var string
+     * @var null|string
      */
     private $name;
+
+    /**
+     * Image alt text.
+     *
+     * @var null|string
+     */
+    private $altText;
 
     /**
      * Image type.
@@ -145,14 +152,16 @@ class Image extends AbstractElement
      * @param string $source
      * @param mixed $style
      * @param bool $watermark
-     * @param string $name
+     * @param null|string $name
+     * @param null|string $altText
      */
-    public function __construct($source, $style = null, $watermark = false, $name = null)
+    public function __construct($source, $style = null, $watermark = false, $name = null, $altText = null)
     {
         $this->source = $source;
         $this->style = $this->setNewStyle(new ImageStyle(), $style, true);
         $this->setIsWatermark($watermark);
         $this->setName($name);
+        $this->setAltText($altText);
 
         $this->checkImage();
     }
@@ -190,11 +199,31 @@ class Image extends AbstractElement
     /**
      * Sets the image name.
      *
-     * @param string $value
+     * @param null|string $value
      */
     public function setName($value): void
     {
         $this->name = $value;
+    }
+
+    /**
+     * Get image alt text.
+     *
+     * @return null|string
+     */
+    public function getAltText(): ?string 
+    {
+        return $this->altText;
+    }
+
+    /**
+     * Sets the image alt text.
+     *
+     * @param null|string $value
+     */
+    public function setAltText(?string $value): void
+    {
+        $this->altText = $value;
     }
 
     /**

--- a/src/PhpWord/Element/Image.php
+++ b/src/PhpWord/Element/Image.php
@@ -208,18 +208,14 @@ class Image extends AbstractElement
 
     /**
      * Get image alt text.
-     *
-     * @return null|string
      */
-    public function getAltText(): ?string 
+    public function getAltText(): ?string
     {
         return $this->altText;
     }
 
     /**
      * Sets the image alt text.
-     *
-     * @param null|string $value
      */
     public function setAltText(?string $value): void
     {

--- a/src/PhpWord/Reader/Word2007/AbstractPart.php
+++ b/src/PhpWord/Reader/Word2007/AbstractPart.php
@@ -528,15 +528,17 @@ abstract class AbstractPart
             $xmlReader->registerNamespace('a', 'http://schemas.openxmlformats.org/drawingml/2006/main');
 
             $name = $xmlReader->getAttribute('name', $node, 'wp:inline/a:graphic/a:graphicData/pic:pic/pic:nvPicPr/pic:cNvPr');
+            $altText = $xmlReader->getAttribute('descr', $node, 'wp:inline/a:graphic/a:graphicData/pic:pic/pic:nvPicPr/pic:cNvPr');
             $embedId = $xmlReader->getAttribute('r:embed', $node, 'wp:inline/a:graphic/a:graphicData/pic:pic/pic:blipFill/a:blip');
-            if ($name === null && $embedId === null) { // some Converters puts images on a different path
+            if ($name === null && $altText === null && $embedId === null) { // some Converters puts images on a different path
                 $name = $xmlReader->getAttribute('name', $node, 'wp:anchor/a:graphic/a:graphicData/pic:pic/pic:nvPicPr/pic:cNvPr');
+                $altText = $xmlReader->getAttribute('descr', $node, 'wp:anchor/a:graphic/a:graphicData/pic:pic/pic:nvPicPr/pic:cNvPr');
                 $embedId = $xmlReader->getAttribute('r:embed', $node, 'wp:anchor/a:graphic/a:graphicData/pic:pic/pic:blipFill/a:blip');
             }
             $target = $this->getMediaTarget($docPart, $embedId);
             if ($this->hasImageLoading() && null !== $target) {
                 $imageSource = "zip://{$this->docFile}#{$target}";
-                $parent->addImage($imageSource, null, false, $name);
+                $parent->addImage($imageSource, null, false, $name, $altText);
             }
         } elseif ($node->nodeName == 'w:object') {
             // Object

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -947,10 +947,15 @@ class Html
     {
         $style = [];
         $src = null;
+        $altText = null;
         foreach ($node->attributes as $attribute) {
             switch ($attribute->name) {
                 case 'src':
                     $src = $attribute->value;
+
+                    break;
+                case 'alt':
+                    $altText = $attribute->value;
 
                     break;
                 case 'width':
@@ -1039,7 +1044,7 @@ class Html
         }
 
         if (is_file($src)) {
-            $newElement = $element->addImage($src, $style);
+            $newElement = $element->addImage($src, $style, false, null, $altText);
         } else {
             throw new Exception("Could not load image $originSrc");
         }

--- a/src/PhpWord/Writer/HTML/Element/Image.php
+++ b/src/PhpWord/Writer/HTML/Element/Image.php
@@ -45,8 +45,14 @@ class Image extends Text
             $style = $styleWriter->write();
             $imageData = 'data:' . $this->element->getImageType() . ';base64,' . $imageData;
 
+            $altText = $this->element->getAltText();
+            $altAttribute = '';
+            if ($altText) {
+                $altAttribute = " alt=\"{$altText}\"";
+            }
+
             $content .= $this->writeOpening();
-            $content .= "<img border=\"0\" style=\"{$style}\" src=\"{$imageData}\"/>";
+            $content .= "<img border=\"0\" style=\"{$style}\" src=\"{$imageData}\"{$altAttribute}/>";
             $content .= $this->writeClosing();
         }
 

--- a/src/PhpWord/Writer/Word2007/Element/Image.php
+++ b/src/PhpWord/Writer/Word2007/Element/Image.php
@@ -81,6 +81,10 @@ class Image extends AbstractElement
         $xmlWriter->writeAttribute('type', '#_x0000_t75');
         $xmlWriter->writeAttribute('stroked', 'f');
 
+        if ($element->getAltText() != null) {
+            $xmlWriter->writeAttribute('alt', $element->getAltText());
+        }
+
         $styleWriter->write();
 
         $xmlWriter->startElement('v:imagedata');

--- a/tests/PhpWordTests/Element/ImageTest.php
+++ b/tests/PhpWordTests/Element/ImageTest.php
@@ -39,6 +39,7 @@ class ImageTest extends AbstractWebServerEmbedded
         self::assertEquals(md5($src), $oImage->getMediaId());
         self::assertFalse($oImage->isWatermark());
         self::assertEquals(Image::SOURCE_LOCAL, $oImage->getSourceType());
+        self::assertNull($oImage->getAltText());
         self::assertInstanceOf('PhpOffice\\PhpWord\\Style\\Image', $oImage->getStyle());
     }
 
@@ -109,6 +110,16 @@ class ImageTest extends AbstractWebServerEmbedded
         );
 
         self::assertInstanceOf('PhpOffice\\PhpWord\\Style\\Image', $oImage->getStyle());
+    }
+
+    /**
+     * Get alt text.
+     */
+    public function testAltText(): void {
+        $source = __DIR__ . '/../_files/images/earth.jpg';
+        $altText = 'Picture of the earth from space';
+        $image = new Image($source, null, false, null, $altText);
+        self::assertEquals($altText, $image->getAltText());
     }
 
     /**

--- a/tests/PhpWordTests/Element/ImageTest.php
+++ b/tests/PhpWordTests/Element/ImageTest.php
@@ -115,7 +115,8 @@ class ImageTest extends AbstractWebServerEmbedded
     /**
      * Get alt text.
      */
-    public function testAltText(): void {
+    public function testAltText(): void
+    {
         $source = __DIR__ . '/../_files/images/earth.jpg';
         $altText = 'Picture of the earth from space';
         $image = new Image($source, null, false, null, $altText);

--- a/tests/PhpWordTests/Reader/Word2007/ElementTest.php
+++ b/tests/PhpWordTests/Reader/Word2007/ElementTest.php
@@ -338,7 +338,7 @@ class ElementTest extends AbstractTestReader
                             <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
                                 <pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
                                     <pic:nvPicPr>
-                                        <pic:cNvPr id="1" name="file_name.jpg"/>
+                                        <pic:cNvPr id="1" name="file_name.jpg" descr="file description" />
                                         <pic:cNvPicPr/>
                                     </pic:nvPicPr>
                                     <pic:blipFill>

--- a/tests/PhpWordTests/Shared/HtmlTest.php
+++ b/tests/PhpWordTests/Shared/HtmlTest.php
@@ -926,7 +926,7 @@ HTML;
 
         $phpWord = new PhpWord();
         $section = $phpWord->addSection();
-        $html = '<p><img src="' . $src . '" width="150" height="200" style="float: right;"/><img src="' . $src . '" style="float: left;"/></p>';
+        $html = '<p><img src="' . $src . '" width="150" height="200" style="float: right;"/><img src="' . $src . '" style="float: left;" alt="Firefox logo"/></p>';
         Html::addHtml($section, $html);
 
         $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
@@ -937,6 +937,7 @@ HTML;
         self::assertStringMatchesFormat('%Sheight:200px%S', $doc->getElementAttribute($baseXpath . '[1]/w:pict/v:shape', 'style'));
         self::assertStringMatchesFormat('%Smso-position-horizontal:right%S', $doc->getElementAttribute($baseXpath . '[1]/w:pict/v:shape', 'style'));
         self::assertStringMatchesFormat('%Smso-position-horizontal:left%S', $doc->getElementAttribute($baseXpath . '[2]/w:pict/v:shape', 'style'));
+        self::assertStringMatchesFormat('%SFirefox logo%S', $doc->getElementAttribute($baseXpath . '[2]/w:pict/v:shape', 'alt'));
     }
 
     /**

--- a/tests/PhpWordTests/Writer/Word2007/Part/DocumentTest.php
+++ b/tests/PhpWordTests/Writer/Word2007/Part/DocumentTest.php
@@ -392,9 +392,11 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $styles = ['alignment' => Jc::START, 'width' => 40, 'height' => 40, 'marginTop' => -1, 'marginLeft' => -1];
         $wraps = ['inline', 'behind', 'infront', 'square', 'tight'];
         $section = $phpWord->addSection();
+        $source = __DIR__ . '/../../../_files/images/earth.jpg';
+        $altText = 'Picture of the earth from space';
         foreach ($wraps as $wrap) {
             $styles['wrappingStyle'] = $wrap;
-            $section->addImage(__DIR__ . '/../../../_files/images/earth.jpg', $styles);
+            $section->addImage($source, $styles, false, null, $altText);
         }
 
         $archiveFile = realpath(__DIR__ . '/../../../_files/documents/reader.docx');
@@ -403,6 +405,10 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $section->addImage($source);
 
         $doc = TestHelperDOCX::getDocument($phpWord);
+
+        // alt text
+        $element = $doc->getElement('/w:document/w:body/w:p[2]/w:r/w:pict/v:shape');
+        self::assertEquals($altText, $element->getAttribute('alt'));
 
         // behind
         $element = $doc->getElement('/w:document/w:body/w:p[2]/w:r/w:pict/v:shape');


### PR DESCRIPTION
### Description

In order to remain compatible with the origin, this fork will adopt the image alt text code from it.

Fixes # (issue)

### Checklist:

- [ ] My CI is :green_circle:
- [ ] I have covered by unit tests my new code (check build/coverage for coverage report)
- [ ] I have updated the [documentation](https://github.com/PHPOffice/PHPWord/tree/master/docs) to describe the changes
- [ ] I have updated the [changelog](https://github.com/PHPOffice/PHPWord/blob/master/docs/changes/1.x/1.5.0.md)
